### PR TITLE
Stochastic Approximation for network estimation

### DIFF
--- a/R/01-networks_estimation.R
+++ b/R/01-networks_estimation.R
@@ -83,6 +83,7 @@ fit_main <- netest(
   target.stats = netstats_main,
   coef.diss = netstats$main$diss.byage,
   set.control.ergm = control.ergm(
+    main.method = "Stochastic-Approximation",
     MCMLE.maxit = 500,
     SAN.maxit = 3,
     SAN.nsteps.times = 4,
@@ -128,6 +129,7 @@ fit_casl <- netest(
   target.stats = netstats_casl,
   coef.diss = netstats$casl$diss.byage,
   set.control.ergm = control.ergm(
+    main.method = "Stochastic-Approximation",
     MCMLE.maxit = 500,
     SAN.maxit = 3,
     SAN.nsteps.times = 4,
@@ -171,6 +173,7 @@ fit_inst <- netest(
   target.stats = netstats_inst,
   coef.diss = dissolution_coefs(~ offset(edges), 1),
   set.control.ergm = control.ergm(
+    main.method = "Stochastic-Approximation",
     MCMLE.maxit = 500,
     SAN.maxit = 3,
     SAN.nsteps.times = 4,


### PR DESCRIPTION
uses the "Stochastic-Approximation" `main.method` to massively speed up the network estimations.