### PR TITLE
Add deploy-doctor watch-list teardown to the HPC workflow scaffold

### DIFF
--- a/R/C-calibration/workflow-ballpark_calib.R
+++ b/R/C-calibration/workflow-ballpark_calib.R
@@ -31,6 +31,11 @@ control <- control_msm(
 # Workflow creation ------------------------------------------------------------
 wf <- make_em_workflow("ballpark_calib", override = TRUE)
 
+# Register this campaign in the deploy-doctor watch list. Pairs with the teardown
+# step at the end; together they stop the shared deploy doctor (launched from the
+# deploy script) once this is the last campaign still running. Requires EpiModelHPC.
+wf <- add_doctor_register_step(wf, "ballpark_calib")
+
 # Using scenarios --------------------------------------------------------------
 
 # Define calibration scenarios
@@ -99,3 +104,7 @@ wf <- add_workflow_step(
     "mem-per-cpu" = "5G"
   )
 )
+
+# Final step: deregister from the deploy-doctor watch list and stop the shared
+# doctor once this is the last campaign still running (EpiModelHPC).
+wf <- add_doctor_teardown_step(wf, "ballpark_calib")

--- a/R/C-calibration/workflow-restart_calib.R
+++ b/R/C-calibration/workflow-restart_calib.R
@@ -34,6 +34,11 @@ control <- control_msm(
 # Workflow creation ------------------------------------------------------------
 wf <- make_em_workflow("restart_calib", override = TRUE)
 
+# Register this campaign in the deploy-doctor watch list. Pairs with the teardown
+# step at the end; together they stop the shared deploy doctor (launched from the
+# deploy script) once this is the last campaign still running. Requires EpiModelHPC.
+wf <- add_doctor_register_step(wf, "restart_calib")
+
 # Using scenarios --------------------------------------------------------------
 
 # Define calibration scenarios
@@ -113,3 +118,7 @@ wf <- add_workflow_step(
     "mem-per-cpu" = "5G"
   )
 )
+
+# Final step: deregister from the deploy-doctor watch list and stop the shared
+# doctor once this is the last campaign still running (EpiModelHPC).
+wf <- add_doctor_teardown_step(wf, "restart_calib")

--- a/R/C-calibration/workflow-swfcalib.R
+++ b/R/C-calibration/workflow-swfcalib.R
@@ -24,6 +24,11 @@ source("R/C-calibration/swfcalib_config.R", local = TRUE)
 
 wf <- make_em_workflow("swfcalib", override = TRUE)
 
+# Register this campaign in the deploy-doctor watch list. Pairs with the teardown
+# step at the end; together they stop the shared deploy doctor (launched from the
+# deploy script) once this is the last campaign still running. Requires EpiModelHPC.
+wf <- add_doctor_register_step(wf, "swfcalib")
+
 # Calibration step 1
 wf <- add_workflow_step(
   wf_summary = wf,
@@ -161,3 +166,7 @@ wf <- add_workflow_step(
     "mem-per-cpu" = "5G"
   )
 )
+
+# Final step: deregister from the deploy-doctor watch list and stop the shared
+# doctor once this is the last campaign still running (EpiModelHPC).
+wf <- add_doctor_teardown_step(wf, "swfcalib")

--- a/R/D-interventions/workflow-intervention.R
+++ b/R/D-interventions/workflow-intervention.R
@@ -33,6 +33,11 @@ control <- control_msm(
 # Workflow creation
 wf <- make_em_workflow("interventions", override = TRUE)
 
+# Register this campaign in the deploy-doctor watch list. Pairs with the teardown
+# step at the end; together they stop the shared deploy doctor (launched from the
+# deploy script) once this is the last campaign still running. Requires EpiModelHPC.
+wf <- add_doctor_register_step(wf, "interventions")
+
 # Define test scenarios
 scenarios_df <- read.csv("data/input/scenarios.csv")
 scenarios_list <- EpiModel::create_scenario_list(scenarios_df)
@@ -104,3 +109,7 @@ wf <- add_workflow_step(
     "mem-per-cpu" = "5G"
   )
 )
+
+# Final step: deregister from the deploy-doctor watch list and stop the shared
+# doctor once this is the last campaign still running (EpiModelHPC).
+wf <- add_doctor_teardown_step(wf, "interventions")

--- a/R/hpc-doctor/README.md
+++ b/R/hpc-doctor/README.md
@@ -1,0 +1,30 @@
+# Deploy doctor (project launcher)
+
+The deploy-doctor logic lives in the **EpiModelHPC** package (`inst/hpc_doctor/`), not in this repo. Projects invoke it through `EpiModelHPC::hpc_doctor_script()`, so there is no private copy here to drift from the package.
+
+This directory holds one project-specific file:
+
+- `deploy_doctor.sbatch`: the SLURM launcher. Replace the three placeholders (`<HPC_PROJECT_DIR>`, `<HPC_MAIL_USER>`, `<JOB_NAME_PATTERN>`) before first use.
+
+## Launch
+
+Launch the doctor from the deploy script, idempotently, alongside a campaign (once at least one workflow's renv-restore step has installed EpiModelHPC on the node):
+
+```bash
+ssh "$HPC" "squeue -u \$USER -h -o '%j' | grep -qx deploy_doctor || (cd <HPC_PROJECT_DIR> && sbatch R/hpc-doctor/deploy_doctor.sbatch)"
+```
+
+Report-only (no requeues): `sbatch --export=ALL,ACT= R/hpc-doctor/deploy_doctor.sbatch`.
+
+## Teardown (automatic, from the workflow)
+
+The doctor is one job shared across every concurrent campaign whose name matches its `PATTERN`, so it must be stopped only when the **last** campaign finishes, not when any single workflow does. Each workflow does this with the two EpiModelHPC watch-list steps, added in the generator:
+
+```r
+wf <- make_em_workflow("my_campaign", override = TRUE)
+wf <- add_doctor_register_step(wf, "my_campaign")   # near the start
+# ... netsim / merge / process steps ...
+wf <- add_doctor_teardown_step(wf, "my_campaign")   # last step
+```
+
+The register step marks the campaign live in a watch-list directory (`data/run/.doctor_watch`, gitignored); the teardown step removes that marker and stops the doctor only once the directory is empty. It is race-free across simultaneous finishes and runs even if an earlier step fails (`afterany` chaining). See `?add_doctor_teardown_step`. Register and teardown are a matched pair: a workflow that registers but never tears down leaves a stale marker that blocks teardown for other campaigns.

--- a/R/hpc-doctor/deploy_doctor.sbatch
+++ b/R/hpc-doctor/deploy_doctor.sbatch
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Project launcher for the EpiModelHPC deploy doctor: a one-CPU companion job
+# that sweeps for CPU-starved / degenerate SLURM tasks over the life of a
+# campaign, requeues them, and self-terminates when its watched jobs drain. The
+# doctor LOGIC lives in the EpiModelHPC package (inst/hpc_doctor/, resolved at
+# runtime via EpiModelHPC::hpc_doctor_script()), so this repo carries no copy of
+# the scripts and cannot drift from the package. This launcher is the only
+# project-specific piece.
+#
+# BEFORE FIRST USE, replace the three placeholders:
+#   <HPC_PROJECT_DIR>   absolute path to this project's checkout on the cluster
+#                       (e.g. /projects/epimodel/<user>/<Project>), in BOTH the
+#                       cd and the --output line below.
+#   <HPC_MAIL_USER>     SLURM notification address (e.g. you@emory.edu).
+#   <JOB_NAME_PATTERN>  extended-regex matching THIS project's campaign job names
+#                       ONLY (e.g. '(restart_point|myproj_.*|swfcalib)'). It must
+#                       not match other projects' jobs running on the account.
+#
+# Launch it once per deploy, idempotently, from the deploy script (after at least
+# one workflow's renv-restore step has installed EpiModelHPC on the node):
+#   ssh "$HPC" "squeue -u \$USER -h -o '%j' | grep -qx deploy_doctor || (cd <HPC_PROJECT_DIR> && sbatch R/hpc-doctor/deploy_doctor.sbatch)"
+#
+# The workflows stop it automatically once the last campaign finishes, via
+# EpiModelHPC::add_doctor_teardown_step() (see this directory's README.md), so it
+# does not need a manual scancel.
+#
+#   sbatch R/hpc-doctor/deploy_doctor.sbatch
+#   sbatch --export=ALL,ACT= R/hpc-doctor/deploy_doctor.sbatch   # report-only
+#
+#SBATCH --job-name=deploy_doctor
+#SBATCH --partition=week-long-cpu,day-long-cpu,epimodel
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=2G
+#SBATCH --time=7-00:00:00
+#SBATCH --nice=9000000
+#SBATCH --mail-type=END,FAIL
+#SBATCH --mail-user=<HPC_MAIL_USER>
+#SBATCH --output=<HPC_PROJECT_DIR>/data/run/deploy_doctor_%j.log
+
+set -u
+cd <HPC_PROJECT_DIR>
+. /projects/epimodel/spack/share/spack/setup-env.sh
+spack unload -a
+spack load r@4.5.1
+
+# Resolve the doctor from the installed EpiModelHPC package (not a repo copy).
+# The path is wrapped in markers because renv's startup messages print to stdout
+# during activation; extract only what is between the markers.
+DOCTOR=$(Rscript -e 'cat("@@P@@", EpiModelHPC::hpc_doctor_script("deploy_doctor.sh"), "@@E@@", sep="")' 2>/dev/null | sed -n 's/.*@@P@@\(.*\)@@E@@.*/\1/p')
+test -n "$DOCTOR" && test -f "$DOCTOR" || { echo "ERROR: could not resolve doctor script (got: '$DOCTOR')" >&2; exit 1; }
+
+# PATTERN must match THIS project's campaign job names only.
+PATTERN='<JOB_NAME_PATTERN>' bash "$DOCTOR"


### PR DESCRIPTION
Scaffolds the deploy-doctor watch-list teardown into the template so new projects get it by default.

The deploy doctor is one shared companion job launched per deploy, so it must be stopped only when the last campaign finishes, not when any single workflow does. EpiModelHPC 2.6.0 (on hpc-worker-cleanup-and-doctor) adds add_doctor_register_step and add_doctor_teardown_step for exactly that, via a marker directory. This PR wires the calls into the template workflow generators and ships the project launcher.

- intervention and the three calibration generators: register step right after make_em_workflow, teardown as the final step.
- new R/hpc-doctor/deploy_doctor.sbatch launcher (project dir / mail user / job-name PATTERN placeholders) plus a README covering launch and teardown.

Depends on EpiModelHPC 2.6.0 (add_doctor_register_step / add_doctor_teardown_step).